### PR TITLE
Prevent page scrolling on game controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -104,23 +104,29 @@ function hardDrop() {
 
 function handleKey(e) {
   if (!currentColumn) return;
+  let handled = false;
   switch (e.code) {
     case 'ArrowLeft':
       if (canMoveLeft()) columnX--;
+      handled = true;
       break;
     case 'ArrowRight':
       if (canMoveRight()) columnX++;
+      handled = true;
       break;
     case 'ArrowDown':
       hardDrop();
+      handled = true;
       break;
     case 'Space':
       rotateColumn();
+      handled = true;
       break;
-    default:
-      return;
   }
-  renderGrid();
+  if (handled) {
+    e.preventDefault();
+    renderGrid();
+  }
 }
 
 function lockColumn() {


### PR DESCRIPTION
## Summary
- disable default scrolling when using arrow keys or space bar

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_686a9cb372788322859ea7278e5377e7