### PR TITLE
Add title and remove gridlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <h1 id="title">Fruitris</h1>
   <div id="grid" class="grid"></div>
   <script src="game.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -5,6 +5,7 @@
 body {
   margin: 0;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
@@ -12,11 +13,16 @@ body {
   font-family: sans-serif;
 }
 
+#title {
+  margin-bottom: 16px;
+  font-size: 2rem;
+}
+
 #grid {
   display: grid;
   grid-template-columns: repeat(10, var(--cell-size));
   grid-template-rows: repeat(20, var(--cell-size));
-  gap: 2px;
+  gap: 0;
   background: #ddd;
   padding: 4px;
 }
@@ -25,7 +31,7 @@ body {
   width: var(--cell-size);
   height: var(--cell-size);
   background: #fff;
-  border: 1px solid #ccc;
+  border: none;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- display a Fruitris title above the game grid
- stack the title and grid vertically
- remove cell borders and spacing so no gridlines show

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686a9e53a49c8322a3038c2dc9440ed6