### PR TITLE
Add timer, dynamic speed and game over handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
 </head>
 <body>
   <h1 id="title">Fruitris</h1>
+  <div id="info">
+    <span id="time">00:00</span>
+    <span id="score">Score: 0</span>
+  </div>
+  <div id="gameOver">Game Over</div>
   <div id="grid" class="grid"></div>
   <script src="game.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -18,6 +18,18 @@ body {
   font-size: 2rem;
 }
 
+#info {
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+}
+
+#gameOver {
+  margin-bottom: 8px;
+  font-size: 1.5rem;
+  color: red;
+  display: none;
+}
+
 #grid {
   display: grid;
   grid-template-columns: repeat(10, var(--cell-size));


### PR DESCRIPTION
## Summary
- display score and elapsed time
- include Game Over message above the grid
- use new fruit set
- make falling speed increase on an S-curve
- end game if new column can't spawn

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_b_686aa0bc63e88322974bfcf4bbf1de59