### PR TITLE
Fix drop timing and show controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -49,6 +49,8 @@ function spawnColumn() {
   columnX = Math.floor(Math.random() * gridWidth);
   // start just above the grid so the top fruit appears immediately
   columnY = -1;
+  // reset drop timer so new column begins falling immediately
+  lastDrop = performance.now();
   for (let i = 0; i < 3; i++) {
     const y = i;
     if (grid[y][columnX]) {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   </div>
   <div id="gameOver">Game Over</div>
   <div id="grid" class="grid"></div>
+  <div id="controls">Use ←/→ to move, ↓ to drop, space to rotate.</div>
   <script src="game.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -21,6 +21,8 @@ body {
 #info {
   margin-bottom: 8px;
   font-size: 1.2rem;
+  display: flex;
+  gap: 1rem;
 }
 
 #gameOver {
@@ -28,6 +30,11 @@ body {
   font-size: 1.5rem;
   color: red;
   display: none;
+}
+
+#controls {
+  margin-top: 8px;
+  font-size: 1rem;
 }
 
 #grid {


### PR DESCRIPTION
## Summary
- ensure new columns drop immediately by resetting `lastDrop`
- show on-screen controls beneath the grid
- improve layout of info bar with flexbox styling

## Testing
- `node --check game.js`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_b_686aa441bb888322a4a21f9d61359063