### PR TITLE
Update scoring and game over checks

### DIFF
--- a/game.js
+++ b/game.js
@@ -230,7 +230,8 @@ function processMatches() {
     matches.forEach(({ x, y }) => {
       grid[y][x] = null;
     });
-    score += matches.length;
+    const matchedCount = matches.length;
+    score += Math.floor((matchedCount / 3) * matchedCount);
     updateScore();
     applyGravity();
     renderGrid();
@@ -273,14 +274,21 @@ function handleKey(e) {
 }
 
 function lockColumn() {
+  let outOfBounds = false;
   for (let i = 0; i < 3; i++) {
     const y = columnY + i;
-    if (y >= 0 && y < gridHeight) {
+    if (y < 0) {
+      outOfBounds = true;
+    } else if (y < gridHeight) {
       grid[y][columnX] = currentColumn[i];
     }
   }
   currentColumn = null;
-  processMatches();
+  if (outOfBounds) {
+    endGame();
+  } else {
+    processMatches();
+  }
 }
 
 function update(timestamp) {

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <h1 id="title">Fruitris</h1>
   <div id="info">
-    <span id="time">00:00</span>
+    <span>Time: <span id="time">00:00</span></span>
     <span id="score">Score: 0</span>
   </div>
   <div id="gameOver">Game Over</div>


### PR DESCRIPTION
## Summary
- ensure game over triggers when locked column reaches above the grid
- label the timer display with "Time:"
- scale score rewards by number of fruit cleared at once

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686b6cda394083228142c4a59db232f1