### PR TITLE
Add restart control and reorganize UI layout

### DIFF
--- a/game.js
+++ b/game.js
@@ -5,6 +5,7 @@ const scoreDisplay = document.getElementById('score');
 const gameOverDisplay = document.getElementById('gameOver');
 const touchControls = document.getElementById('touchControls');
 const difficultyRadios = document.querySelectorAll('input[name="difficulty"]');
+const restartButton = document.getElementById('restartButton');
 
 let startTouchX = 0;
 let startTouchY = 0;
@@ -351,6 +352,26 @@ function endGame() {
   gameOverDisplay.style.display = 'block';
 }
 
+function restartGame() {
+  grid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(null));
+  currentColumn = null;
+  columnX = 0;
+  columnY = 0;
+  isClearing = false;
+  startTime = null;
+  score = 0;
+  nextSpecialTime = 30 + Math.random() * 15;
+  updateScore();
+  updateTime(0);
+  gameOver = false;
+  gameOverDisplay.style.display = 'none';
+  const selected = document.querySelector('input[name="difficulty"]:checked');
+  if (selected) setDifficulty(selected.value);
+  spawnColumn(0);
+  renderGrid();
+  requestAnimationFrame(update);
+}
+
 function processMatches() {
   const matches = findMatches();
   if (matches.length === 0) {
@@ -386,8 +407,16 @@ function hardDrop() {
 }
 
 function handleKey(e) {
-  if (!currentColumn) return;
   let handled = false;
+  if (e.code === 'KeyR') {
+    restartGame();
+    handled = true;
+  }
+  if (!currentColumn) {
+    if (handled) e.preventDefault();
+    return;
+  }
+  
   switch (e.code) {
     case 'ArrowLeft':
       if (canMoveLeft()) columnX--;
@@ -522,10 +551,7 @@ function update(timestamp) {
   requestAnimationFrame(update);
 }
 
-setDifficulty('standard');
-updateScore();
-updateTime(0);
-spawnColumn(0);
+restartButton.addEventListener('click', restartGame);
 document.addEventListener('keydown', handleKey);
 if (touchControls) {
   touchControls.addEventListener('click', handleTouch);
@@ -541,4 +567,4 @@ difficultyRadios.forEach(r =>
   })
 );
 
-requestAnimationFrame(update);
+restartGame();

--- a/index.html
+++ b/index.html
@@ -11,29 +11,36 @@
 </head>
 <body>
   <h1 id="title">Fruitris</h1>
-  <div id="info">
-    <span>Time: <span id="time">00:00</span></span>
-    <span id="score">Score: 0</span>
-  </div>
-  <div id="difficulty">
-    <label><input type="radio" name="difficulty" value="easy"> Easy</label>
-    <label><input type="radio" name="difficulty" value="standard" checked> Standard</label>
-    <label><input type="radio" name="difficulty" value="hard"> Hard</label>
-  </div>
-  <div id="gameOver">Game Over</div>
-  <div id="grid" class="grid"></div>
-  <div id="touchControls">
-    <button data-action="left">⬅️</button>
-    <button data-action="rotate">🔄</button>
-    <button data-action="right">➡️</button>
-    <button data-action="drop">⬇️</button>
-  </div>
-  <div id="controls">Use ←/→ to move, ↓ to drop, space to rotate.</div>
-  <div id="touchControls">
-    <button data-action="left">⬅️</button>
-    <button data-action="rotate">🔄</button>
-    <button data-action="right">➡️</button>
-    <button data-action="drop">⬇️</button>
+  <div id="layout">
+    <div id="sidebar">
+      <div id="info">
+        <span>Time: <span id="time">00:00</span></span>
+        <span id="score">Score: 0</span>
+      </div>
+      <div id="difficulty">
+        <label><input type="radio" name="difficulty" value="easy"> Easy</label>
+        <label><input type="radio" name="difficulty" value="standard" checked> Standard</label>
+        <label><input type="radio" name="difficulty" value="hard"> Hard</label>
+      </div>
+      <button id="restartButton">Restart</button>
+    </div>
+    <div id="gameArea">
+      <div id="gameOver">Game Over</div>
+      <div id="grid" class="grid"></div>
+      <div id="touchControls">
+        <button data-action="left">⬅️</button>
+        <button data-action="rotate">🔄</button>
+        <button data-action="right">➡️</button>
+        <button data-action="drop">⬇️</button>
+      </div>
+    </div>
+    <div id="instructions">
+      <h2>How to Play</h2>
+      <p><strong>Aim:</strong> Align three matching fruits horizontally, vertically or diagonally to clear them.</p>
+      <p><strong>Touch:</strong> Use the on-screen buttons or swipe left/right, swipe down to drop and tap the column to rotate.</p>
+      <p><strong>Keys:</strong> ←/→ move, ↓ drop, space rotate, R restart.</p>
+      <p><strong>Specials:</strong> 💣 clears all matching fruit below, 🔫 clears to the left, 🏹 clears diagonally up-left.</p>
+    </div>
   </div>
   <script>
     const cacheBuster = Date.now();

--- a/style.css
+++ b/style.css
@@ -6,7 +6,6 @@ body {
   margin: 0;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   height: 100vh;
   background: #f9f9f9;
@@ -16,6 +15,25 @@ body {
 #title {
   margin-bottom: 16px;
   font-size: 2rem;
+}
+
+#layout {
+  display: grid;
+  grid-template-columns: 150px auto 220px;
+  gap: 1rem;
+  align-items: start;
+}
+
+#sidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+#instructions {
+  max-width: 220px;
+  font-size: 0.9rem;
+  line-height: 1.3;
 }
 
 #info {
@@ -33,6 +51,10 @@ body {
   margin-right: 0.5rem;
 }
 
+#restartButton {
+  margin-top: 8px;
+}
+
 #gameOver {
   margin-bottom: 8px;
   font-size: 1.5rem;
@@ -40,10 +62,6 @@ body {
   display: none;
 }
 
-#controls {
-  margin-top: 8px;
-  font-size: 1rem;
-}
 
 #touchControls {
   display: none;
@@ -91,8 +109,12 @@ body {
   :root {
     --cell-size: 24px;
   }
-  #controls {
-    display: none;
+  #layout {
+    grid-template-columns: 1fr;
+  }
+  #instructions {
+    order: 3;
+    margin-top: 8px;
   }
   #touchControls {
     display: grid;


### PR DESCRIPTION
## Summary
- add left sidebar with time, score, difficulty and restart button
- add instructions panel explaining aim, controls and specials
- implement `restartGame()` and keyboard shortcut `R`
- move layout to a 3-column grid and adjust styles

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_b_686d59edc6a883229fbbd573208c1a94