### PR TITLE
Update layout and effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,20 +10,7 @@
   <link id="mainStyle" rel="stylesheet">
 </head>
 <body>
-  <h1 id="title">Fruitris</h1>
   <div id="layout">
-    <div id="sidebar">
-      <div id="info">
-        <span>Time: <span id="time">00:00</span></span>
-        <span id="score">Score: 0</span>
-      </div>
-      <div id="difficulty">
-        <label><input type="radio" name="difficulty" value="easy"> Easy</label>
-        <label><input type="radio" name="difficulty" value="standard" checked> Standard</label>
-        <label><input type="radio" name="difficulty" value="hard"> Hard</label>
-      </div>
-      <button id="restartButton">Restart</button>
-    </div>
     <div id="gameArea">
       <div id="gameOver">Game Over</div>
       <div id="grid" class="grid"></div>
@@ -34,12 +21,27 @@
         <button data-action="drop">⬇️</button>
       </div>
     </div>
-    <div id="instructions">
-      <h2>How to Play</h2>
-      <p><strong>Aim:</strong> Align three matching fruits horizontally, vertically or diagonally to clear them.</p>
-      <p><strong>Touch:</strong> Use the on-screen buttons or swipe left/right, swipe down to drop and tap the column to rotate.</p>
-      <p><strong>Keys:</strong> ←/→ move, ↓ drop, space rotate, R restart.</p>
-      <p><strong>Specials:</strong> 💣 clears all matching fruit below, 🔫 clears to the left, 🏹 clears diagonally up-left.</p>
+    <div id="rightPanel">
+      <h1 id="title">Fruitris</h1>
+      <div id="sidebar">
+        <div id="info">
+          <span>Time: <span id="time">00:00</span></span>
+          <span id="score">Score: 0</span>
+        </div>
+        <div id="difficulty">
+          <label><input type="radio" name="difficulty" value="easy"> Easy</label>
+          <label><input type="radio" name="difficulty" value="standard" checked> Standard</label>
+          <label><input type="radio" name="difficulty" value="hard"> Hard</label>
+        </div>
+        <button id="restartButton">Restart</button>
+      </div>
+      <div id="instructions">
+        <h2>How to Play</h2>
+        <p><strong>Aim:</strong> Align three or more matching fruits horizontally, vertically or diagonally to clear them.</p>
+        <p><strong>Touch:</strong> Use the on-screen buttons or swipe left/right, swipe down to drop and tap the column to rotate.</p>
+        <p><strong>Keys:</strong> ←/→ move, ↓ drop, space rotate, R restart.</p>
+        <p><strong>Specials:</strong> 💣 clears all matching fruit below, 🔫 clears to the left, 🏹 clears diagonally up-right.</p>
+      </div>
     </div>
   </div>
   <script>

--- a/style.css
+++ b/style.css
@@ -4,10 +4,10 @@
 
 body {
   margin: 0;
+  padding: 1rem;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  height: 100vh;
+  align-items: flex-start;
+  justify-content: flex-start;
   background: #f9f9f9;
   font-family: sans-serif;
 }
@@ -19,9 +19,15 @@ body {
 
 #layout {
   display: grid;
-  grid-template-columns: 150px auto 220px;
+  grid-template-columns: auto 220px;
   gap: 1rem;
   align-items: start;
+}
+
+#rightPanel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 #sidebar {
@@ -83,7 +89,7 @@ body {
 #grid {
   display: grid;
   grid-template-columns: repeat(10, var(--cell-size));
-  grid-template-rows: repeat(20, var(--cell-size));
+  grid-template-rows: repeat(15, var(--cell-size));
   gap: 0;
   background: #ddd;
   padding: 4px;
@@ -102,7 +108,7 @@ body {
 }
 
 .highlight {
-  background: rgba(0, 0, 0, 0.05);
+  background: #fafafa;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- align layout to top-left and move info to a new right panel
- shrink the board to 15 rows and lighten column highlight
- keep new columns in the same position as the last drop
- adjust 🏹 power to clear up-right
- add simple pop and bop sounds
- update instructions for new gameplay

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_686d5c8ae3cc832281a10d7df2999688