### PR TITLE
Adjust title and overlay positions

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link id="mainStyle" rel="stylesheet">
 </head>
 <body>
+  <h1 id="title">Fruitris</h1>
   <div id="layout">
     <div id="gameArea">
       <div id="gameOver">Game Over</div>
@@ -22,7 +23,6 @@
       </div>
     </div>
     <div id="rightPanel">
-      <h1 id="title">Fruitris</h1>
       <div id="sidebar">
         <div id="info">
           <span>Time: <span id="time">00:00</span></span>

--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@ body {
 
 #layout {
   display: grid;
-  grid-template-columns: auto 220px;
+  grid-template-columns: auto 260px;
   gap: 1rem;
   align-items: start;
 }
@@ -30,6 +30,10 @@ body {
   align-items: flex-start;
 }
 
+#gameArea {
+  position: relative;
+}
+
 #sidebar {
   display: flex;
   flex-direction: column;
@@ -37,7 +41,7 @@ body {
 }
 
 #instructions {
-  max-width: 220px;
+  max-width: 260px;
   font-size: 0.9rem;
   line-height: 1.3;
 }
@@ -62,10 +66,17 @@ body {
 }
 
 #gameOver {
-  margin-bottom: 8px;
-  font-size: 1.5rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 2rem;
   color: red;
   display: none;
+  pointer-events: none;
 }
 
 


### PR DESCRIPTION
## Summary
- place game title above the layout
- overlay the Game Over message on the grid
- widen sidebar and instructions panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d5e94d2e0832285b2ada07e17c3bd