### PR TITLE
Improve game layout, controls and audio

### DIFF
--- a/game.js
+++ b/game.js
@@ -12,10 +12,10 @@ let startTouchY = 0;
 
 // simple sound effects using Web Audio API
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-function playSound(freq, duration) {
+function playSound(freq, duration, type = 'sine') {
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
-  osc.type = 'sine';
+  osc.type = type;
   osc.frequency.value = freq;
   osc.connect(gain);
   gain.connect(audioCtx.destination);
@@ -29,6 +29,11 @@ function playPop() {
 }
 function playBop() {
   playSound(250, 0.15);
+}
+
+function playLoseSound() {
+  playSound(200, 0.3, 'square');
+  setTimeout(() => playSound(150, 0.3, 'square'), 150);
 }
 
 const gridWidth = 10;
@@ -388,6 +393,7 @@ function resolveSpecialClears(cells) {
 function endGame() {
   gameOver = true;
   gameOverDisplay.style.display = 'block';
+  playLoseSound();
 }
 
 function restartGame() {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link id="mainStyle" rel="stylesheet">
 </head>
 <body>
@@ -33,7 +34,7 @@
           <label><input type="radio" name="difficulty" value="standard" checked> Standard</label>
           <label><input type="radio" name="difficulty" value="hard"> Hard</label>
         </div>
-        <button id="restartButton">Restart</button>
+        <button id="restartButton">Restart game</button>
       </div>
       <div id="instructions">
         <h2>How to Play</h2>

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ body {
   margin: 0;
   padding: 1rem;
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
   background: #f9f9f9;
@@ -75,21 +76,18 @@ body {
   border-radius: 4px;
   font-size: 2rem;
   color: red;
+  font-family: 'Press Start 2P', cursive;
+  white-space: nowrap;
   display: none;
   pointer-events: none;
 }
 
 
 #touchControls {
-  display: none;
+  display: grid;
   margin-top: 8px;
   gap: 16px;
   grid-template-columns: repeat(4, 1fr);
-}
-
-#touchControls button {
-  font-size: 2.5rem;
-  padding: 8px 12px;
 }
 
 #touchControls button {


### PR DESCRIPTION
## Summary
- display game title above playfield
- show touch controls on all screen sizes
- rename restart button to 'Restart game'
- style Game Over text with 8‑bit font and prevent wrapping
- play square wave 'lose' jingle on Game Over

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d6031e42883228b69bcad36c5ff82