### PR TITLE
Update fruit set and UI tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,9 +133,8 @@ Refer to [`PLAN.md`](./PLAN.md) for detailed milestones and [`README.md`](./READ
 Use the following emoji pool for fruits:
 
 ```js
-const fruitTypes = [‘🍓’, ‘🍌’, ‘🍇’, ‘🍍’, ‘🍎’, ‘🍒’];
+const fruitTypes = ['🥥', '🍌', '🍇', '🍊', '🍏', '🍒'];
 ```
 
 —
-
 *End of Codex Agent Guidelines*

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,7 +18,7 @@ This document outlines the planned phases and tasks for building **Fruitris**, a
 
 ### Falling Fruit Columns
 - [ ] Define difficulty level (speed of falling and number of fruit)
-- [x] Define emoji set (`🍓`, `🍌`, `🍇`, `🍍`, `🍏`, `🍒`)
+- [x] Define emoji set (`🥥`, `🍌`, `🍇`, `🍊`, `🍏`, `🍒`)
 - [x] Generate 3-emoji vertical column at top of grid
 - [x] Animate column falling over time
 - [x] Allow movement: ← (left), → (right), ↓ (faster fall), ‘ ‘ (space; rotate fruit in column)

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ The game ends when the stacked fruit reaches the top of the playfield and can no
 
 ## 📦 Features
 
-- 🍓 Falling columns made of 3 random fruit emojis (number of fruit based on difficulty level (just 🍌, 🍒, 🍏 to start with, in a random order within column)
+- 🥥 Falling columns made of 3 random fruit emojis (number of fruit based on difficulty level — starting set is 🥥, 🍌 and 🍇 in a random order within each column)
 - 🔃 Rotate order of fruit by pressing space before dropping
 - 🧠 Match-3 detection in **8 directions** (up, down, left, right, and diagonals)
 - 🍒 Gravity-based settling after clears
 - 💣 Bomb clears all fruit matching the one it lands on
 - 🔫 Gun clears all fruit to its right
 - 🏹 Arrow clears the diagonal toward the top-left
-- 🍍 Combo chaining for advanced play
-- 🍎 Game over detection and restart flow
+- 🍊 Combo chaining for advanced play
+- 🍏 Game over detection and restart flow
 - 💻 Local-only game — runs entirely in the browser (no backend)
 
 —

--- a/game.js
+++ b/game.js
@@ -31,6 +31,14 @@ function playBop() {
   playSound(250, 0.15);
 }
 
+function initAudio() {
+  if (audioCtx.state === 'suspended') {
+    audioCtx.resume();
+  }
+}
+document.addEventListener('keydown', initAudio, { once: true });
+document.addEventListener('touchstart', initAudio, { once: true });
+
 const gridWidth = 10;
 const gridHeight = 15;
 
@@ -48,7 +56,8 @@ for (let y = 0; y < gridHeight; y++) {
 // Create 2D grid array
 let grid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(null));
 
-const baseFruits = ['🍓', '🍌', '🍇', '🍍', '🍎', '🍒'];
+// base fruit set
+const baseFruits = ['🥥', '🍌', '🍇', '🍊', '🍏', '🍒'];
 let fruitTypes = baseFruits.slice(0, 4); // standard difficulty default
 const specialTypes = ['💣', '🔫', '🏹'];
 
@@ -112,10 +121,6 @@ function updateCell(x, y, emoji) {
 }
 
 function renderGrid() {
-  // clear existing column highlights
-  document.querySelectorAll('.cell.highlight').forEach(c => {
-    c.classList.remove('highlight');
-  });
   // reset transforms on all cells
   document.querySelectorAll('.cell').forEach(c => {
     c.style.transform = '';
@@ -141,13 +146,6 @@ function renderGrid() {
         );
         if (cell) cell.style.transform = `translateY(${offset}px)`;
       }
-    }
-    // highlight the entire column
-    for (let y = 0; y < gridHeight; y++) {
-      const cell = document.querySelector(
-        `.cell[data-x="${columnX}"][data-y="${y}"]`
-      );
-      if (cell) cell.classList.add('highlight');
     }
   }
 }
@@ -447,12 +445,13 @@ function hardDrop() {
 
 function handleKey(e) {
   let handled = false;
+  const blockKeys = ['Space', 'ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'];
+  if (blockKeys.includes(e.code)) e.preventDefault();
   if (e.code === 'KeyR') {
     restartGame();
     handled = true;
   }
   if (!currentColumn) {
-    if (handled) e.preventDefault();
     return;
   }
   

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
   <link id="mainStyle" rel="stylesheet">
 </head>
 <body>
-  <h1 id="title">Fruitris</h1>
   <div id="layout">
     <div id="gameArea">
       <div id="gameOver">Game Over</div>
@@ -23,6 +22,7 @@
       </div>
     </div>
     <div id="rightPanel">
+      <h1 id="title">🍌🍇 Fruitris 🍒🍊</h1>
       <div id="sidebar">
         <div id="info">
           <span>Time: <span id="time">00:00</span></span>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@ body {
 #title {
   margin-bottom: 16px;
   font-size: 2rem;
+  font-family: 'Comic Sans MS', cursive, sans-serif;
 }
 
 #layout {
@@ -119,9 +120,6 @@ body {
   transition: transform 0.1s ease;
 }
 
-.highlight {
-  background: #fafafa;
-}
 
 @media (max-width: 480px) {
   :root {


### PR DESCRIPTION
## Summary
- update the base fruit emojis to use 🥥, 🍌, 🍇, 🍊, 🍏 and 🍒
- remove column highlight shading
- move page title above controls and spice it up with emoji and new font
- resume audio context on first interaction
- block page scrolling from space and arrow keys
- update docs with new emoji set

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d61857eac8322bc7a2b4ea59580ed