### PR TITLE
Disable selection highlight on game area

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,6 +34,12 @@ body {
 
 #gameArea {
   position: relative;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#gameArea:focus {
+  outline: none;
 }
 
 #sidebar {
@@ -103,6 +109,7 @@ body {
   gap: 0;
   background: #ddd;
   padding: 4px;
+  user-select: none;
 }
 
 .cell {


### PR DESCRIPTION
## Summary
- prevent text selection or focus outlines on the game grid

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_686d64017de883228e56370a19d6880c