### PR TITLE
Remove grey highlight around play area

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,9 +107,10 @@ body {
   grid-template-columns: repeat(10, var(--cell-size));
   grid-template-rows: repeat(15, var(--cell-size));
   gap: 0;
-  background: #ddd;
-  padding: 4px;
+  padding: 0;
+  background: none;
   user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .cell {
@@ -123,6 +124,7 @@ body {
   font-size: 1.5rem;
   box-sizing: border-box;
   transition: transform 0.1s ease;
+  -webkit-tap-highlight-color: transparent;
 }
 
 


### PR DESCRIPTION
## Summary
- eliminate grey background and padding around the play area
- disable mobile tap highlight on the grid and fruit cells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e3e146eb883229e493b5a99f898a3