### PR TITLE
Add chiptune sound effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The game ends when the stacked fruit reaches the top of the playfield and can no
 - 🏹 Arrow clears the diagonal toward the top-left
 - 🍊 Combo chaining for advanced play
 - 🍏 Game over detection and restart flow
+- 🎵 Retro 8-bit sound effects
 - 💻 Local-only game — runs entirely in the browser (no backend)
 
 —
@@ -35,7 +36,7 @@ The game ends when the stacked fruit reaches the top of the playfield and can no
 | Move right   | → arrow    |
 | Drop faster  | ↓ arrow    |
 | Rotate       | <space>    |
-| Restart game | R (planned)|
+| Restart game | R |
 | Touch play   | On-screen buttons or swipe/tap |
 
 —


### PR DESCRIPTION
## Summary
- implement 8-bit style audio playback with WebAudio API
- add event hooks for movement, rotation, drops, matches and specials
- play restart and game over jingles
- document retro sound effects in README

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_b_686e4079bba88322b8361b1f0a27a71a