### PR TITLE
Improve mobile play area

### DIFF
--- a/game.js
+++ b/game.js
@@ -110,7 +110,7 @@ document.addEventListener('keydown', initAudio, { once: true });
 document.addEventListener('touchstart', initAudio, { once: true });
 
 const gridWidth = 10;
-const gridHeight = 15;
+const gridHeight = 20;
 
 // Create grid cells in the DOM
 for (let y = 0; y < gridHeight; y++) {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Fruitris</title>
+  <title>Et tu, Fruitus?</title>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -17,13 +17,13 @@
       <div id="grid" class="grid"></div>
       <div id="touchControls">
         <button data-action="left">⬅️</button>
-        <button data-action="rotate">🔄</button>
         <button data-action="right">➡️</button>
+        <button data-action="rotate">🔄</button>
         <button data-action="drop">⬇️</button>
       </div>
     </div>
     <div id="rightPanel">
-      <h1 id="title">🍌🍇 Fruitris 🍒🍊</h1>
+      <h1 id="title">🍌🍇 Et tu, Fruitus? 🍒🍊</h1>
       <div id="sidebar">
         <div id="info">
           <span>Time: <span id="time">00:00</span></span>

--- a/style.css
+++ b/style.css
@@ -105,7 +105,7 @@ body {
 #grid {
   display: grid;
   grid-template-columns: repeat(10, var(--cell-size));
-  grid-template-rows: repeat(15, var(--cell-size));
+  grid-template-rows: repeat(20, var(--cell-size));
   gap: 0;
   padding: 0;
   background: none;
@@ -121,7 +121,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 1.5rem;
+  font-size: 2rem;
   box-sizing: border-box;
   transition: transform 0.1s ease;
   -webkit-tap-highlight-color: transparent;
@@ -130,7 +130,7 @@ body {
 
 @media (max-width: 480px) {
   :root {
-    --cell-size: 24px;
+    --cell-size: 32px;
   }
   #layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- enlarge game grid to fill mobile screens
- move left/right buttons together
- show new title
- make fruit bigger for easier touch control

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e4b2ea17083228dc5521559f6f285