### PR TITLE
Add skull emoji special

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -41,7 +41,7 @@ This document outlines the planned phases and tasks for building **Fruitris**, a
 
 - [x] Apply gravity to fruits above cleared cells
 - [x] Re-check for new matches (chain reactions)
-- [ ] Add special power emoji (💣 = clear all emoji on screen below bomb; 🏹 = clear all emoji in column; 🗡️ clear all emoji in row)
+- [ ] Add special power emoji (💣 = clear all emoji on screen below bomb; 🏹 = clear all emoji in column; 🗡️ clear all emoji in row; ☠️ lingers for 1 minute)
 - [ ] Update score per emoji cleared and chain multiplier
 
 —

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The game ends when the stacked fruit reaches the top of the playfield and can no
 - 💣 Bomb clears all fruit matching the one it lands on
 - 🔫 Gun clears all fruit to its right
 - 🏹 Arrow clears the diagonal toward the top-left
+- ☠️ Skull blocks a cell for 1 minute, flashing before it disappears
 - ☄️ Extra bonus and meteor celebration when clearing more than six fruits at once
 - 🍊 Combo chaining for advanced play
 - 🍏 Game over detection and restart flow

--- a/game.js
+++ b/game.js
@@ -133,7 +133,8 @@ let grid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(null))
 // base fruit set
 const baseFruits = ['🥥', '🍌', '🍇', '🍊', '🍏', '🍒'];
 let fruitTypes = baseFruits.slice(0, 4); // standard difficulty default
-const specialTypes = ['💣', '🔫', '🏹'];
+const skullEmoji = '☠️';
+const specialTypes = ['💣', '🔫', '🏹', skullEmoji];
 
 let nextSpecialTime = 30 + Math.random() * 15; // seconds until first special
 
@@ -147,6 +148,7 @@ let startTime = null;
 let score = 0;
 let gameOver = false;
 let fallProgress = 0; // fraction between drops for smooth animation
+const skullTimers = new Map();
 
 const startInterval = 1000; // ms
 const minInterval = 100; // ms
@@ -267,7 +269,7 @@ function findMatches() {
   for (let y = 0; y < gridHeight; y++) {
     for (let x = 0; x < gridWidth; x++) {
       const fruit = grid[y][x];
-      if (!fruit) continue;
+      if (!fruit || fruit === skullEmoji) continue;
 
       for (const [dx, dy] of dirs) {
         const prevX = x - dx;
@@ -335,11 +337,10 @@ function bigClearCelebration(count) {
   // award additional bonus points for large clears
   const bonus = Math.floor((count / 3) * count);
   score += bonus;
-  scoreDisplay.textContent = `Score: ${score} ☄️`;
+  scoreDisplay.textContent = `Score: ${score}`;
   scoreDisplay.classList.add('flash');
   setTimeout(() => {
     scoreDisplay.classList.remove('flash');
-    scoreDisplay.textContent = `Score: ${score}`;
   }, 600);
   playBigClearSound();
 }
@@ -396,6 +397,25 @@ function scheduleNextSpecial(elapsed, dropInterval) {
   nextSpecialTime = elapsed + interval;
 }
 
+function scheduleSkull(x, y) {
+  const key = `${x},${y}`;
+  const cell = document.querySelector(`.cell[data-x="${x}"][data-y="${y}"]`);
+  const flashTimeout = setTimeout(() => {
+    if (cell) cell.classList.add('blink');
+  }, 50000);
+  const removeTimeout = setTimeout(() => {
+    if (cell) cell.classList.remove('blink');
+    if (grid[y][x] === skullEmoji) {
+      grid[y][x] = null;
+      applyGravity();
+      renderGrid();
+      setTimeout(processMatches, 200);
+    }
+    skullTimers.delete(key);
+  }, 60000);
+  skullTimers.set(key, [flashTimeout, removeTimeout]);
+}
+
 function handleSpecial(x, y, emoji) {
   const cells = [];
   if (emoji === '💣') {
@@ -416,18 +436,18 @@ function handleSpecial(x, y, emoji) {
   } else if (emoji === '🔫') {
     // Gun now fires to the left instead of the right
     for (let xx = x - 1; xx >= 0; xx--) {
-      if (grid[y][xx]) cells.push({ x: xx, y });
+      if (grid[y][xx] && grid[y][xx] !== skullEmoji) cells.push({ x: xx, y });
     }
   } else if (emoji === '🏹') {
     let sx = x + 1;
     let sy = y - 1;
     while (sx < gridWidth && sy >= 0) {
-      if (grid[sy][sx]) cells.push({ x: sx, y: sy });
+      if (grid[sy][sx] && grid[sy][sx] !== skullEmoji) cells.push({ x: sx, y: sy });
       sx++;
       sy--;
     }
   }
-  cells.push({ x, y });
+  if (emoji !== skullEmoji) cells.push({ x, y });
   return cells;
 }
 
@@ -450,8 +470,9 @@ function resolveSpecialClears(cells) {
   });
 
   isClearing = true;
+  const clearEmoji = unique.length > 6 ? '☄️' : '💥';
   unique.forEach(({ x, y }) => {
-    grid[y][x] = '💥';
+    grid[y][x] = clearEmoji;
   });
   renderGrid();
 
@@ -487,6 +508,12 @@ function restartGame() {
   columnX = 0;
   columnY = 0;
   isClearing = false;
+  skullTimers.forEach(t => {
+    clearTimeout(t[0]);
+    clearTimeout(t[1]);
+  });
+  skullTimers.clear();
+  document.querySelectorAll('.cell.blink').forEach(c => c.classList.remove('blink'));
   startTime = null;
   score = 0;
   nextSpecialTime = 30 + Math.random() * 15;
@@ -510,8 +537,9 @@ function processMatches() {
 
   isClearing = true;
   console.log('Match found:', matches.length, 'cells');
+  const clearEmoji = matches.length > 6 ? '☄️' : '💥';
   matches.forEach(({ x, y }) => {
-    grid[y][x] = '💥';
+    grid[y][x] = clearEmoji;
   });
   renderGrid();
 
@@ -692,7 +720,11 @@ function lockColumn() {
   } else {
     const cleared = [];
     specials.forEach(s => {
-      cleared.push(...handleSpecial(s.x, s.y, s.emoji));
+      if (s.emoji === skullEmoji) {
+        scheduleSkull(s.x, s.y);
+      } else {
+        cleared.push(...handleSpecial(s.x, s.y, s.emoji));
+      }
     });
     resolveSpecialClears(cleared);
   }

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <p><strong>Aim:</strong> Align three or more matching fruits horizontally, vertically or diagonally to clear them.</p>
         <p><strong>Touch:</strong> Use the on-screen buttons or swipe left/right, swipe down to drop and tap the column to rotate.</p>
         <p><strong>Keys:</strong> ←/→ move, ↓ drop, space rotate, R restart.</p>
-        <p><strong>Specials:</strong> 💣 clears all matching fruit below, 🔫 clears to the left, 🏹 clears diagonally up-right.</p>
+        <p><strong>Specials:</strong> 💣 clears all matching fruit below, 🔫 clears to the left, 🏹 clears diagonally up-right, ☠️ stays for a minute then vanishes.</p>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -141,6 +141,10 @@ body {
   animation: flash 0.3s ease-in-out 0s 2;
 }
 
+.cell.blink {
+  animation: flash 0.5s linear infinite;
+}
+
 
 @media (max-width: 480px) {
   :root {


### PR DESCRIPTION
## Summary
- add ☠️ to specials and show instructions for new emoji
- skull stays for 1 minute and flashes before vanishing
- update PLAN and README
- meteor now shows during big clears instead of next to the score

## Testing
- `node -c game.js`


------
https://chatgpt.com/codex/tasks/task_b_68735e233b788322911c31150e9070ee