### PR TITLE
Add level-up overlay and skull scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,10 @@
 </head>
 <body>
   <div id="layout">
-    <div id="gameArea">
-      <div id="gameOver">Game Over</div>
-      <div id="level">Level 1</div>
+      <div id="gameArea">
+        <div id="gameOver">Game Over</div>
+        <div id="levelUp" class="level-up"></div>
+        <div id="level">Level 1</div>
       <div id="grid" class="grid"></div>
       <div id="touchControls">
         <button data-action="left">⬅️</button>

--- a/style.css
+++ b/style.css
@@ -89,6 +89,22 @@ body {
   pointer-events: none;
 }
 
+.level-up {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 2rem;
+  color: green;
+  font-family: 'Press Start 2P', cursive;
+  white-space: nowrap;
+  display: none;
+  pointer-events: none;
+}
+
 #level {
   text-align: center;
   font-family: 'Press Start 2P', cursive;


### PR DESCRIPTION
## Summary
- add a level-up overlay element in `index.html`
- style the new overlay with Press Start font
- play success sound and clear board on level up
- ramp up ☠️ chance per level

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_b_6873d977b4d483228b4c3f52116f4c4c