### PR TITLE
Implement new specials, level scaling and UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <div id="gameArea">
         <div id="gameOver">Game Over</div>
         <div id="levelUp" class="level-up"></div>
-        <div id="level">Level 1</div>
+        <div id="levelBar"><span id="level">Level 1</span> <span id="scoreTop">Score: 0</span></div>
       <div id="grid" class="grid"></div>
       <div id="touchControls">
         <button data-action="left">⬅️</button>

--- a/style.css
+++ b/style.css
@@ -105,11 +105,18 @@ body {
   pointer-events: none;
 }
 
-#level {
-  text-align: center;
-  font-family: 'Press Start 2P', cursive;
+#levelBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 4px;
+  font-family: 'Press Start 2P', cursive;
   font-size: 1.2rem;
+}
+
+#level,
+#scoreTop {
+  margin: 0 4px;
 }
 
 


### PR DESCRIPTION
## Summary
- display score next to level above the board
- reduce score thresholds for levels by 50%
- add several new special emoji powers
- replace skull emoji with helmet emoji and adjust spawn logic
- preserve board on level up and manage timers when resetting

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_b_6873fd5829ac8322b94d79f252407df9